### PR TITLE
fix crash error: QMessageBox only has StandardButton enum, not Standa…

### DIFF
--- a/original/pyqt6/firstprograms.md
+++ b/original/pyqt6/firstprograms.md
@@ -282,10 +282,10 @@ class Example(QWidget):
     def closeEvent(self, event):
 
         reply = QMessageBox.question(self, 'Message',
-                    "Are you sure to quit?", QMessageBox.StandardButtons.Yes |
-                    QMessageBox.StandardButtons.No, QMessageBox.StandardButtons.No)
+                    "Are you sure to quit?", QMessageBox.StandardButton.Yes |
+                    QMessageBox.StandardButton.No, QMessageBox.StandardButton.No)
 
-        if reply == QMessageBox.StandardButtons.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
 
             event.accept()
         else:

--- a/translated/pyqt6/firstprograms.md
+++ b/translated/pyqt6/firstprograms.md
@@ -280,10 +280,10 @@ class Example(QWidget):
     def closeEvent(self, event):
 
         reply = QMessageBox.question(self, 'Message',
-                    "Are you sure to quit?", QMessageBox.StandardButtons.Yes |
-                    QMessageBox.StandardButtons.No, QMessageBox.StandardButtons.No)
+                    "Are you sure to quit?", QMessageBox.StandardButton.Yes |
+                    QMessageBox.StandardButton.No, QMessageBox.StandardButton.No)
 
-        if reply == QMessageBox.StandardButtons.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
 
             event.accept()
         else:


### PR DESCRIPTION
PYQT_VERSION_STR：6.2.3
QMessageBox only has a StandardButton enum, not StandardButtons.
[](https://www.riverbankcomputing.com/static/Docs/PyQt6/api/qtwidgets/qmessagebox.html?highlight=standardbuttons#StandardButton)