### PR TITLE
fix QPainter.RenderHint from QPainter.RenderHints

### DIFF
--- a/translated/pyqt6/painting.md
+++ b/translated/pyqt6/painting.md
@@ -535,7 +535,7 @@ class Example(QWidget):
 
         qp = QPainter()
         qp.begin(self)
-        qp.setRenderHint(QPainter.RenderHints.Antialiasing)
+        qp.setRenderHint(QPainter.RenderHint.Antialiasing)
         self.drawBezierCurve(qp)
         qp.end()
 


### PR DESCRIPTION
In pyqt6 6.3.1, only QPainter.RenderHint is valid